### PR TITLE
a series of optimizations

### DIFF
--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -236,9 +236,10 @@ RDKit::VECT_INT_VECT findCoreRings(const RDKit::VECT_INT_VECT &fusedRings,
           }
         }
       }
-      // note that the set of ring is not SSSR because we use symmetrizeSSSR, so
-      // we cannot force a check for only one fused ring. Instead we make sure
-      // that this ring shares only one atom or one bond (two consecutive atoms)
+      // note that the set of rings is not SSSR because we use symmetrizeSSSR,
+      // so we cannot force a check for only one fused ring. Instead we make
+      // sure that this ring shares only one atom or one bond (two consecutive
+      // atoms)
       if (nIntersectingAtoms == 1 ||
           (nIntersectingAtoms == 2 &&
            mol.getBondBetweenAtoms(aid1, aid2) != nullptr)) {

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -211,35 +211,37 @@ RDKit::VECT_INT_VECT findCoreRings(const RDKit::VECT_INT_VECT &fusedRings,
       if (removedRings[currRingId] || removedARing) {
         continue;
       }
-      std::set<int> allIntersectingAtoms;
-      RDKit::INT_VECT commmonAtoms;
+      auto nIntersectingAtoms = 0u;
+      int aid1 = -1;
+      int aid2 = -1;
       for (unsigned int otherRingId = 0; otherRingId < fusedRings.size();
            otherRingId++) {
         if (currRingId == otherRingId || removedRings[otherRingId]) {
           continue;
         }
+        RDKit::INT_VECT commmonAtoms;
         RDKit::Intersect(fusedRings[currRingId], fusedRings[otherRingId],
                          commmonAtoms);
-        if (commmonAtoms.size() > 0) {
-          for (auto rii : commmonAtoms) {
-            allIntersectingAtoms.insert(rii);
+        for (auto rii : commmonAtoms) {
+          if (rii != aid1 && rii != aid2) {
+            ++nIntersectingAtoms;
+            if (aid1 == -1) {
+              aid1 = rii;
+            } else {
+              aid2 = rii;
+            }
+            if (nIntersectingAtoms == 2) {
+              break;
+            }
           }
         }
       }
       // note that the set of ring is not SSSR because we use symmetrizeSSSR, so
       // we cannot force a check for only one fused ring. Instead we make sure
       // that this ring shares only one atom or one bond (two consecutive atoms)
-      auto hasOneOrTwoConsecutiveAtoms = [&mol](const RDKit::INT_VECT &vec) {
-        if (vec.size() == 1) {
-          return true;
-        } else if (vec.size() == 2) {
-          return mol.getBondBetweenAtoms(vec[0], vec[1]) != nullptr;
-        }
-        return false;
-      };
-      RDKit::INT_VECT allIntersectingAtomsVec(allIntersectingAtoms.begin(),
-                                              allIntersectingAtoms.end());
-      if (hasOneOrTwoConsecutiveAtoms(allIntersectingAtomsVec)) {
+      if (nIntersectingAtoms == 1 ||
+          (nIntersectingAtoms == 2 &&
+           mol.getBondBetweenAtoms(aid1, aid2) != nullptr)) {
         removedRings[currRingId] = true;
         removedARing = true;
       }

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -229,7 +229,7 @@ RDKit::VECT_INT_VECT findCoreRings(const RDKit::VECT_INT_VECT &fusedRings,
       // note that the set of ring is not SSSR because we use symmetrizeSSSR, so
       // we cannot force a check for only one fused ring. Instead we make sure
       // that this ring shares only one atom or one bond (two consecutive atoms)
-      auto hasOneOrTwoConsecutiveAtoms = [mol](const RDKit::INT_VECT &vec) {
+      auto hasOneOrTwoConsecutiveAtoms = [&mol](const RDKit::INT_VECT &vec) {
         if (vec.size() == 1) {
           return true;
         } else if (vec.size() == 2) {

--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -252,8 +252,10 @@ TEST_CASE("match template with added rings") {
   // generate coordinates
   RDDepict::Compute2DCoordParameters params;
   params.useRingTemplates = true;
-  RDDepict::compute2DCoords(*mol1, params);
-  RDDepict::compute2DCoords(*mol2, params);
+  for (auto i = 0; i < 1000; ++i) {
+    RDDepict::compute2DCoords(*mol1, params);
+    RDDepict::compute2DCoords(*mol2, params);
+  }
 
   // align the two molecules
   auto rmsd = MolAlign::getBestRMS(*mol1, *mol2);

--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -252,10 +252,8 @@ TEST_CASE("match template with added rings") {
   // generate coordinates
   RDDepict::Compute2DCoordParameters params;
   params.useRingTemplates = true;
-  for (auto i = 0; i < 1000; ++i) {
-    RDDepict::compute2DCoords(*mol1, params);
-    RDDepict::compute2DCoords(*mol2, params);
-  }
+  RDDepict::compute2DCoords(*mol1, params);
+  RDDepict::compute2DCoords(*mol2, params);
 
   // align the two molecules
   auto rmsd = MolAlign::getBestRMS(*mol1, *mol2);


### PR DESCRIPTION
There are a number of optimizations and cleanups here.
The two big ones:
1. Get rid of the `hasOneOrTwoConsecutiveAtoms` macro: this was copying the argument molecule instead of using a reference (getting rid of that already sped things up), but it was even quicker to make the code a bit harder to read and get rid of the lambda entirely
2. Stop removing atoms and bonds from the molecule before doing the substruture match. The modification accomplishes the same effect by setting the atomic numbers of all atoms that should not be considered to 200 (so they don't match anything in the template). This also makes it unnecessary to track original atom indices with properties