### PR TITLE
fix an out-of-bounds write in `matchToTemplate()`

### DIFF
--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -454,7 +454,7 @@ bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms,
     }
     // also check if the mol atoms have the same connectivity as the template
     auto degreeCounts = [DUMMY_ATOMIC_NUM](const RDKit::ROMol &mol) {
-      std::array<int, 4> degrees_count({0, 0, 0, 0});
+      std::array<int, 5> degrees_count({0, 0, 0, 0, 0});
       for (auto atom : mol.atoms()) {
         if (atom->getAtomicNum() == DUMMY_ATOMIC_NUM) {
           continue;


### PR DESCRIPTION
This was causing the tests to fail